### PR TITLE
Remove browse categories from desktop view

### DIFF
--- a/apps/docs/src/index.css
+++ b/apps/docs/src/index.css
@@ -239,6 +239,8 @@ code, pre {
 .rounded { border-radius: var(--radius); }
 .rounded-lg { border-radius: var(--radius-lg); }
 
+.show-mobile { display: none !important; }
+
 @media (max-width: 600px) {
   .container {
     max-width: 100vw;


### PR DESCRIPTION
Hide "Browse categories" button on desktop as it's redundant with the existing left-side category picker.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f639f45-6b88-46c7-a3e2-c3e7914de57e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f639f45-6b88-46c7-a3e2-c3e7914de57e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

